### PR TITLE
CI: Run only on `master` branch, PRs and version tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
----
+branches:
+  only:
+    - master
+    # npm version tags
+    - /^v\d+\.\d+\.\d+/
+
 language: node_js
 node_js:
   - "6"


### PR DESCRIPTION
to take the load off TravisCI from all the dependabot updates