### PR TITLE
Drop support for Node 4 and 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ branches:
 
 language: node_js
 node_js:
-  - "6"
+  - "8"
 
 sudo: false
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "mocha": "^6.2.2"
   },
   "engines": {
-    "node": ">= 4"
+    "node": "8.* || 10.* || >= 12.*"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
This should unblock a few of the pending dependency updates