### PR TITLE
CI: Disable `node_modules` caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ addons:
   chrome: stable
 
 cache:
+  npm: false
   yarn: true
 
 env:


### PR DESCRIPTION
Our CI is currently flaky because the `node_modules` cache is shared between the different ember-try jobs, which leads to conflicts. Since we already cache the yarn files we can disable the unnecessary caching of `node_modules`.

see https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#caching-with-npm