### PR TITLE
Remove obsolete `ember-cli-htmlbars-inline-precompile` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "ember-cli-dependency-checker": "^3.2.0",
     "ember-cli-eslint": "^4.2.1",
     "ember-cli-htmlbars": "^4.0.8",
-    "ember-cli-htmlbars-inline-precompile": "^2.1.0",
     "ember-cli-inject-live-reload": "^2.0.2",
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-load-initializers": "^2.1.1",


### PR DESCRIPTION
`ember-cli-htmlbars` can take care of this now 🎉 