### PR TITLE
downgrade clean-css to v3 for ember-cli-preprocess-registry parity

### DIFF
--- a/broccoli-clean-css.js
+++ b/broccoli-clean-css.js
@@ -50,11 +50,9 @@ class CleanCSSFilter extends BroccoliPersistentFilter {
   processString(contents, relativePath) {
     let fullPath = path.resolve(this.inputPaths[0], relativePath);
 
-    return this.cleanCSS
-      .minify({
-        [fullPath]: { styles: contents },
-      })
-      .then((result) => result.styles);
+    return this.cleanCSS.minify({
+      [fullPath]: { styles: contents },
+    }).styles;
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "broccoli-persistent-filter": "^3.1.3",
-    "clean-css": "^4.2.3",
+    "clean-css": "^3.4.28",
     "json-stable-stringify": "^1.0.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2706,20 +2706,13 @@ clean-css-promise@^0.1.0:
     clean-css "^3.4.5"
     pinkie-promise "^2.0.0"
 
-clean-css@^3.4.5:
+clean-css@^3.4.28, clean-css@^3.4.5:
   version "3.4.28"
   resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-3.4.28.tgz#bf1945e82fc808f55695e6ddeaec01400efd03ff"
   integrity sha512-aTWyttSdI2mYi07kWqHi24NUU9YlELFKGOAgFzZjDN1064DMAOy2FBuoyGmkKRlXkbpXd0EVHmiVkbKhKoirTw==
   dependencies:
     commander "2.8.x"
     source-map "0.4.x"
-
-clean-css@^4.2.3:
-  version "4.2.4"
-  resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-4.2.4.tgz#733bf46eba4e607c6891ea57c24a989356831178"
-  integrity sha512-EJUDT7nDVFDvaQgAo2G/PJvxmp1o/c6iXLbswsBbUFXi1Nr+AjA2cKmfbKDMjMvzEe75g3P6JkaDDAKk96A85A==
-  dependencies:
-    source-map "~0.6.0"
 
 clean-stack@^2.2.0:
   version "2.2.0"
@@ -7786,7 +7779,7 @@ source-map@^0.5.6:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==
 
-source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.0, source-map@~0.6.1:
+source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==


### PR DESCRIPTION
First step in resolving https://github.com/ember-cli/ember-cli/issues/8457 / https://github.com/ember-cli/ember-cli-preprocess-registry/issues/50